### PR TITLE
Update Vertical Slides to just Slides

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -196,7 +196,7 @@ function reveal_slides() {
 			'notes' => new Fieldmanager_RichTextArea( __( 'Notes', 'reveal' ) ),
 		)
 	) );
-	$fm->add_meta_box( __( 'Vertical Slides', 'reveal' ), 'slide' );
+	$fm->add_meta_box( __( 'Slides', 'reveal' ), 'slide' );
 
 	$fm = new Fieldmanager_Group( array(
 		'name'           => 'wrapper',


### PR DESCRIPTION
As the Vertical Slides Metabox is actually where all slides are added it make sense to change this label to say `Slides` the other option would be to add the `editor` to the CPT and then use the metabox only for vertical slides. However, changing the label is the simplest. The label could also be `Slide(s)` or perhaps change based on slide count. 
