### PR TITLE
Show warning with Fieldmanager is missing or deactive

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -571,6 +571,19 @@ function reveal_homepage_slides( &$query ) {
 	}
 }
 
+function reveal_fm_check_admin_notice__error() {
+	
+	if( !defined( 'FM_VERSION' ) ){
+    ?>
+ 
+    <div class="notice notice-error is-dismissible">
+        <p><?php _e( '<strong>Plugin Required:</strong> Please install the <a href="https://github.com/alleyinteractive/wordpress-fieldmanager">Fieldmanager Plugin </a> to use the reveal.js for WordPress theme.', 'reveal' ); ?></p>
+    </div>
+    <?php
+	    }
+}
+add_action( 'admin_notices', 'reveal_fm_check_admin_notice__error' );
+
 
 /**
  * Template Tags


### PR DESCRIPTION
This shows an Admin Error when the Fieldmanager plugin is either missing or deactive. 

<img width="879" alt="screen shot 2016-05-10 at 11 32 31 pm" src="https://cloud.githubusercontent.com/assets/150348/15172077/4985add6-1708-11e6-96e7-46a6450e707c.png">
